### PR TITLE
make font path default to allow it to be overriden in client projects.

### DIFF
--- a/_font-awesome.scss
+++ b/_font-awesome.scss
@@ -3,7 +3,7 @@
  *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
 
-$fa-font-path: '/packages/reywood_font-awesome-sass/assets/fonts';
+$fa-font-path: '/packages/reywood_font-awesome-sass/assets/fonts' !default;
 
 @import "assets/scss/variables";
 @import "assets/scss/mixins";


### PR DESCRIPTION
Similar to the request in the bootstrap 3 sass package.  Just pulled this into the same project and realized it also needed this update.